### PR TITLE
Compatibilidade laravel 6,7,8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "guzzlehttp/guzzle": "^7.0"
+        "guzzlehttp/guzzle": "^6.0 | ^7.0"
     }
 }


### PR DESCRIPTION
Olá, tudo bem?

Este trecho permite usar a biblioteca de vocês em projetos legados com laravel <= 8. Até esta versão o passport requer o guzzle em versão 6, e o projeto de vocês em versão 7, o que me impossibilitou de instalar. Porém, não tive problemas em usar a versão 6.